### PR TITLE
Fix Gemini streaming parsing for SSE responses

### DIFF
--- a/src/lib/llm/clients.js
+++ b/src/lib/llm/clients.js
@@ -437,7 +437,9 @@ export class GeminiClient extends BaseClient {
     async streamChat(messages, onChunk, modelId = 'gemini-1.5-flash') {
         if (!this.apiKey) throw new Error('Gemini API Key missing');
 
-        const url = `https://generativelanguage.googleapis.com/v1beta/models/${modelId}:streamGenerateContent?key=${this.apiKey}`;
+        const url = new URL(`https://generativelanguage.googleapis.com/v1beta/models/${modelId}:streamGenerateContent`);
+        url.searchParams.set('key', this.apiKey);
+        url.searchParams.set('alt', 'sse');
         const config = THINKING_CONFIG.fields.google;
         const tagParser = new StreamingTagParser();
 
@@ -468,7 +470,7 @@ export class GeminiClient extends BaseClient {
             };
         });
 
-        const response = await fetch(url, {
+        const response = await fetch(url.toString(), {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -498,33 +500,36 @@ export class GeminiClient extends BaseClient {
             buffer = lines.pop() || '';
 
             for (const line of lines) {
-                if (line.trim()) {
-                    try {
-                        const data = JSON.parse(line);
+                const trimmed = line.trim();
+                if (!trimmed.startsWith('data:')) continue;
+                const payload = trimmed.replace(/^data:\s*/, '');
+                if (!payload || payload === '[DONE]') continue;
 
-                        // Check for API-level thinking
-                        const extracted = extractThinking(data.candidates?.[0], config);
+                try {
+                    const data = JSON.parse(payload);
 
-                        if (extracted.thinking) {
-                            onChunk(extracted.thinking, { isThinking: true });
-                        }
+                    // Check for API-level thinking
+                    const extracted = extractThinking(data.candidates?.[0], config);
 
-                        if (extracted.content) {
-                            // Parse for tags
-                            const results = tagParser.processChunk(extracted.content);
-                            for (const result of results) {
-                                onChunk(result.content, { isThinking: result.isThinking });
-                            }
-                        }
-
-                        // Extract finish reason
-                        const finishReason = data.candidates?.[0]?.finishReason;
-                        if (finishReason) {
-                            onChunk('', { finishReason });
-                        }
-                    } catch (e) {
-                        console.error('Error parsing Gemini chunk', e);
+                    if (extracted.thinking) {
+                        onChunk(extracted.thinking, { isThinking: true });
                     }
+
+                    if (extracted.content) {
+                        // Parse for tags
+                        const results = tagParser.processChunk(extracted.content);
+                        for (const result of results) {
+                            onChunk(result.content, { isThinking: result.isThinking });
+                        }
+                    }
+
+                    // Extract finish reason
+                    const finishReason = data.candidates?.[0]?.finishReason;
+                    if (finishReason) {
+                        onChunk('', { finishReason });
+                    }
+                } catch (e) {
+                    console.error('Error parsing Gemini chunk', e);
                 }
             }
         }
@@ -532,17 +537,23 @@ export class GeminiClient extends BaseClient {
         // Process final buffer
         if (buffer.trim()) {
             try {
-                const data = JSON.parse(buffer);
-                const extracted = extractThinking(data.candidates?.[0], config);
+                const trimmed = buffer.trim();
+                if (trimmed.startsWith('data:')) {
+                    const payload = trimmed.replace(/^data:\s*/, '');
+                    if (payload && payload !== '[DONE]') {
+                        const data = JSON.parse(payload);
+                        const extracted = extractThinking(data.candidates?.[0], config);
 
-                if (extracted.thinking) {
-                    onChunk(extracted.thinking, { isThinking: true });
-                }
+                        if (extracted.thinking) {
+                            onChunk(extracted.thinking, { isThinking: true });
+                        }
 
-                if (extracted.content) {
-                    const results = tagParser.processChunk(extracted.content);
-                    for (const result of results) {
-                        onChunk(result.content, { isThinking: result.isThinking });
+                        if (extracted.content) {
+                            const results = tagParser.processChunk(extracted.content);
+                            for (const result of results) {
+                                onChunk(result.content, { isThinking: result.isThinking });
+                            }
+                        }
                     }
                 }
             } catch (e) {


### PR DESCRIPTION
### Motivation
- Gemini streaming responses use SSE-style `data:` payloads and the previous parser attempted to JSON-parse raw lines, which caused failures even with a valid API key. 
- The change ensures the request requests SSE and that only valid SSE `data:` payloads are parsed, avoiding malformed JSON and `[DONE]` markers.

### Description
- Updated `src/lib/llm/clients.js` Gemini client to build the request URL with `new URL(...)`, set the `key` query param and `alt=sse`, and pass `url.toString()` to `fetch`.
- Rewrote the streaming parser loop to only process lines starting with `data:`, strip the prefix, ignore empty payloads and the `[DONE]` sentinel, and then `JSON.parse` the payload safely inside a `try/catch`.
- Preserved the existing thinking-token extraction and tag-based parsing (`extractThinking` and `StreamingTagParser`) but adapted them to the SSE payload shape and updated final-buffer handling to follow the same `data:` payload logic.
- Changes are localized to the Gemini client implementation in `src/lib/llm/clients.js` and maintain existing error handling and finish-reason extraction.

