### PR TITLE
Dynamic Gemini model discovery and SSE streaming parsing fixes

### DIFF
--- a/src/lib/llm/ModelService.js
+++ b/src/lib/llm/ModelService.js
@@ -232,7 +232,8 @@ export class ModelService {
             groq: { models: null, timestamp: null },
             ollama: { models: null, timestamp: null },
             lmstudio: { models: null, timestamp: null },
-            openai: { models: null, timestamp: null }
+            openai: { models: null, timestamp: null },
+            gemini: { models: null, timestamp: null }
         };
         this.CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
     }
@@ -408,6 +409,56 @@ export class ModelService {
         }
     }
 
+    // Fetch models from Gemini (Google Generative Language API)
+    async fetchGeminiModels(apiKey) {
+        if (!apiKey) return [];
+
+        try {
+            if (this.cache.gemini.models && (Date.now() - this.cache.gemini.timestamp < this.CACHE_DURATION)) {
+                return this.cache.gemini.models;
+            }
+
+            const url = new URL('https://generativelanguage.googleapis.com/v1beta/models');
+            url.searchParams.set('key', apiKey);
+
+            const response = await fetch(url.toString());
+
+            if (!response.ok) {
+                throw new Error('Failed to fetch Gemini models');
+            }
+
+            const data = await response.json();
+
+            const models = (data.models || [])
+                .filter(model => {
+                    const methods = model.supportedGenerationMethods || [];
+                    return methods.includes('generateContent') || methods.includes('streamGenerateContent');
+                })
+                .map(model => {
+                    const id = model.name?.replace(/^models\//, '') || model.id;
+                    return {
+                        id,
+                        name: model.displayName || id,
+                        provider: 'gemini',
+                        contextWindow: model.inputTokenLimit,
+                        capabilities: getModelCapabilities(id)
+                    };
+                })
+                .filter(model => model.id)
+                .sort((a, b) => a.id.localeCompare(b.id));
+
+            this.cache.gemini = {
+                models,
+                timestamp: Date.now()
+            };
+
+            return models;
+        } catch (error) {
+            console.error('Error fetching Gemini models:', error);
+            return [];
+        }
+    }
+
     // Clear cache for a specific provider
     clearCache(provider) {
         if (provider && this.cache[provider]) {
@@ -445,14 +496,9 @@ export class ModelService {
         // Fetch LM Studio models
         allModels.lmstudio = await this.fetchLMStudioModels();
 
-        // Add Gemini models (Google doesn't have a public list endpoint)
+        // Fetch Gemini models dynamically
         if (apiKeys.gemini) {
-            allModels.gemini = [
-                { id: 'gemini-2.0-flash-exp', name: 'Gemini 2.0 Flash (Exp)', provider: 'gemini', contextWindow: 1000000, capabilities: getModelCapabilities('gemini-2.0-flash-exp') },
-                { id: 'gemini-1.5-pro', name: 'Gemini 1.5 Pro', provider: 'gemini', contextWindow: 2000000, capabilities: getModelCapabilities('gemini-1.5-pro') },
-                { id: 'gemini-1.5-flash', name: 'Gemini 1.5 Flash', provider: 'gemini', contextWindow: 1000000, capabilities: getModelCapabilities('gemini-1.5-flash') },
-                { id: 'gemini-pro', name: 'Gemini Pro', provider: 'gemini', contextWindow: 32768, capabilities: getModelCapabilities('gemini-pro') }
-            ];
+            allModels.gemini = await this.fetchGeminiModels(apiKeys.gemini);
         }
 
         return allModels;

--- a/src/lib/llm/clients.js
+++ b/src/lib/llm/clients.js
@@ -437,7 +437,9 @@ export class GeminiClient extends BaseClient {
     async streamChat(messages, onChunk, modelId = 'gemini-1.5-flash') {
         if (!this.apiKey) throw new Error('Gemini API Key missing');
 
-        const url = `https://generativelanguage.googleapis.com/v1beta/models/${modelId}:streamGenerateContent?key=${this.apiKey}`;
+        const url = new URL(`https://generativelanguage.googleapis.com/v1beta/models/${modelId}:streamGenerateContent`);
+        url.searchParams.set('key', this.apiKey);
+        url.searchParams.set('alt', 'sse');
         const config = THINKING_CONFIG.fields.google;
         const tagParser = new StreamingTagParser();
 
@@ -468,7 +470,7 @@ export class GeminiClient extends BaseClient {
             };
         });
 
-        const response = await fetch(url, {
+        const response = await fetch(url.toString(), {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -498,33 +500,36 @@ export class GeminiClient extends BaseClient {
             buffer = lines.pop() || '';
 
             for (const line of lines) {
-                if (line.trim()) {
-                    try {
-                        const data = JSON.parse(line);
+                const trimmed = line.trim();
+                if (!trimmed.startsWith('data:')) continue;
+                const payload = trimmed.replace(/^data:\s*/, '');
+                if (!payload || payload === '[DONE]') continue;
 
-                        // Check for API-level thinking
-                        const extracted = extractThinking(data.candidates?.[0], config);
+                try {
+                    const data = JSON.parse(payload);
 
-                        if (extracted.thinking) {
-                            onChunk(extracted.thinking, { isThinking: true });
-                        }
+                    // Check for API-level thinking
+                    const extracted = extractThinking(data.candidates?.[0], config);
 
-                        if (extracted.content) {
-                            // Parse for tags
-                            const results = tagParser.processChunk(extracted.content);
-                            for (const result of results) {
-                                onChunk(result.content, { isThinking: result.isThinking });
-                            }
-                        }
-
-                        // Extract finish reason
-                        const finishReason = data.candidates?.[0]?.finishReason;
-                        if (finishReason) {
-                            onChunk('', { finishReason });
-                        }
-                    } catch (e) {
-                        console.error('Error parsing Gemini chunk', e);
+                    if (extracted.thinking) {
+                        onChunk(extracted.thinking, { isThinking: true });
                     }
+
+                    if (extracted.content) {
+                        // Parse for tags
+                        const results = tagParser.processChunk(extracted.content);
+                        for (const result of results) {
+                            onChunk(result.content, { isThinking: result.isThinking });
+                        }
+                    }
+
+                    // Extract finish reason
+                    const finishReason = data.candidates?.[0]?.finishReason;
+                    if (finishReason) {
+                        onChunk('', { finishReason });
+                    }
+                } catch (e) {
+                    console.error('Error parsing Gemini chunk', e);
                 }
             }
         }
@@ -532,17 +537,23 @@ export class GeminiClient extends BaseClient {
         // Process final buffer
         if (buffer.trim()) {
             try {
-                const data = JSON.parse(buffer);
-                const extracted = extractThinking(data.candidates?.[0], config);
+                const trimmed = buffer.trim();
+                if (trimmed.startsWith('data:')) {
+                    const payload = trimmed.replace(/^data:\s*/, '');
+                    if (payload && payload !== '[DONE]') {
+                        const data = JSON.parse(payload);
+                        const extracted = extractThinking(data.candidates?.[0], config);
 
-                if (extracted.thinking) {
-                    onChunk(extracted.thinking, { isThinking: true });
-                }
+                        if (extracted.thinking) {
+                            onChunk(extracted.thinking, { isThinking: true });
+                        }
 
-                if (extracted.content) {
-                    const results = tagParser.processChunk(extracted.content);
-                    for (const result of results) {
-                        onChunk(result.content, { isThinking: result.isThinking });
+                        if (extracted.content) {
+                            const results = tagParser.processChunk(extracted.content);
+                            for (const result of results) {
+                                onChunk(result.content, { isThinking: result.isThinking });
+                            }
+                        }
                     }
                 }
             } catch (e) {


### PR DESCRIPTION
### Motivation
- Avoid hardcoded Gemini model IDs by discovering available models for a given API key and prevent "model not found" errors. 
- Correctly parse Gemini streaming responses which use SSE `data:` payloads to avoid JSON parse errors and handle `[DONE]` markers.

### Description
- Added `fetchGeminiModels(apiKey)` in `src/lib/llm/ModelService.js` that calls the Google Generative Language API list endpoint, filters models that support `generateContent` or `streamGenerateContent`, maps model metadata into the app schema, and caches results for `5m`.
- Replaced the previous static Gemini model list in `getAllModels` with a dynamic call to `fetchGeminiModels`, and added a `gemini` cache slot.
- Updated `GeminiClient.streamChat` in `src/lib/llm/clients.js` to build the request URL with `new URL(...)`, set the `key` query param and `alt=sse`, and pass `url.toString()` to `fetch`.
- Rewrote the Gemini streaming parser to only process SSE lines starting with `data:`, strip the prefix, ignore empty payloads and the `[DONE]` sentinel, safely `JSON.parse` the payload in a `try/catch`, and preserve existing `extractThinking` and `StreamingTagParser` behavior (including final-buffer handling using the same `data:` logic).

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983644cfac4832eae7fbab4a0d1d832)